### PR TITLE
Update schema.json

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -472,7 +472,7 @@
     {
       "name":"tarif_pmr",
       "description":"Type de tarif horaire pour les PMR.",
-      "example":"42",
+      "example":"normal_payant",
       "type":"string",
       "constraints":{
         "required":false,


### PR DESCRIPTION
Pour "tarif_pmr" l'exemple était "42" mais le champs n'accepte que  "gratuit", "normal_payant" ou "tarif_special". J'ai donc changé l'exemple avec "normal_payant"